### PR TITLE
Add encoder config override

### DIFF
--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import torch
-from omegaconf import open_dict
+from omegaconf import open_dict, OmegaConf
 from peft import PeftModel
 from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -88,14 +88,29 @@ def setup_speech_encoder(model: torch.nn.Module):
     Sets up an ``AudioPerceptionModule``, initializing its ``encoder`` and ``preprocessor``
     with a pretrained NeMo ``ASRModel``.
     The result is assigned to ``model.perception`` attribute and is trainable.
+
+    If user config specifies encoder parameters, they will override the pretrained model's config.
     """
+    # Save user-specified encoder config before loading pretrained model
+    user_encoder_config = {}
+    if 'encoder' in model.cfg.perception:
+        user_encoder_config = OmegaConf.to_container(model.cfg.perception.encoder, resolve=True)
+
     asr = load_pretrained_nemo(ASRModel, model.cfg.pretrained_asr).eval()
     with open_dict(model.cfg):
         model.cfg.perception.preprocessor = asr.cfg.preprocessor
         model.cfg.perception.encoder = asr.cfg.encoder
         model.cfg.perception.output_dim = model.llm.config.hidden_size
+
+        # Override with user-specified encoder parameters
+        if user_encoder_config:
+            for key, value in user_encoder_config.items():
+                if value is not None:  # Only override if user explicitly set a value
+                    model.cfg.perception.encoder[key] = value
+
     model.perception = AudioPerceptionModule(model.cfg.perception).train()
     model.perception.load_state_dict(asr.state_dict(), strict=False)
+
 
 def set_model_dict_for_partial_init(pretrained_dict, model_dict):
     # 1. filter out different size layers


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Allow encoder config to be overwritten.

**Collection**:  speechlm2

# Changelog

- Update `setup_speech_encoder` in `nemo/collections/speechlm2/parts/pretrained.py`.

# Usage

N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
